### PR TITLE
fix: GitHub MCP設定の追加

### DIFF
--- a/.cursorrules
+++ b/.cursorrules
@@ -126,4 +126,34 @@
 ### 将来の拡張
 - AB同時押し、ABC同時押しへの対応
 - シーケンス操作、連続押し判定
-- より複雑なボタン操作パターン 
+- より複雑なボタン操作パターン
+
+## GitHub MCP設定
+
+### リポジトリ情報
+- **Owner**: ycums
+- **Repository**: Aimatix
+- **Default Branch**: main
+
+### MCP設定例
+```bash
+# Issue取得
+github get issues --owner ycums --repo Aimatix
+
+# PR取得
+github get pull-requests --owner ycums --repo Aimatix
+
+# Issue作成
+github create issue --owner ycums --repo Aimatix --title "タイトル" --body "内容"
+```
+
+### エイリアス設定
+```json
+{
+  "aliases": {
+    "github-issues": "github get issues --owner ycums --repo Aimatix",
+    "github-prs": "github get pull-requests --owner ycums --repo Aimatix",
+    "create-issue": "github create issue --owner ycums --repo Aimatix"
+  }
+}
+``` 


### PR DESCRIPTION
## 概要\nGitHub MCPサーバーでリポジトリオーナーを間違える問題の対策\n\n## 変更内容\n- .cursorrules.md → .cursorrules にファイル名修正\n- GitHub MCP用のリポジトリ情報とエイリアス設定を追加\n- リポジトリオーナー: ycums\n\n## 効果\n- Issue取得時にリポジトリオーナーを間違える問題を解決\n- プロジェクト固有のGitHub設定を統一\n\n## テスト\n- [ ] GitHub MCPでのIssue取得テスト\n- [ ] エイリアス設定の動作確認