### PR TITLE
fix: InputDisplayStateの時刻取得問題を修正

### DIFF
--- a/src/DateTimeAdapter.h
+++ b/src/DateTimeAdapter.h
@@ -5,8 +5,24 @@
 
 // M5Stack/ESP32用の日時アダプター
 class DateTimeAdapter : public ITimeProvider {
+private:
+    time_t baseTime = 0;
+    unsigned long baseMillis = 0;
+    
 public:
-    time_t now() const override { return time(nullptr); }
+    time_t now() const override { 
+        time_t current = time(nullptr);
+        
+        // システム時刻が0の場合は、millis()ベースの時刻を使用
+        if (current == 0) {
+            unsigned long currentMillis = millis();
+            time_t estimatedTime = baseTime + (currentMillis - baseMillis) / 1000;
+            return estimatedTime;
+        }
+        
+        return current;
+    }
+    
     struct tm* localtime(time_t* t) const override { return ::localtime(t); }
     
     bool setSystemTime(time_t time) override {
@@ -15,6 +31,19 @@ public:
         tv.tv_usec = 0;
         
         // ESP32でシステム時刻を設定
-        return settimeofday(&tv, nullptr) == 0;
+        bool result = settimeofday(&tv, nullptr) == 0;
+        
+        if (result) {
+            baseTime = time;
+            baseMillis = millis();
+        }
+        
+        return result;
+    }
+    
+    // 起動時の初期化用
+    void initializeTime() {
+        baseTime = 0;
+        baseMillis = millis();
     }
 };

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -101,7 +101,7 @@ ButtonManager button_manager;
 const std::shared_ptr<DateTimeAdapter> m5_time_provider = std::make_shared<DateTimeAdapter>();
 const std::shared_ptr<M5StackTimeManager> m5_time_manager = std::make_shared<M5StackTimeManager>();
 InputLogic input_logic(m5_time_provider);
-InputDisplayState input_display_state(&input_logic, &input_display_view_impl);
+InputDisplayState input_display_state(&input_logic, &input_display_view_impl, m5_time_provider.get());
 MainDisplayState main_display_state(&state_manager, &input_display_state, &main_display_view_impl, &time_logic, &alarm_logic);
 AlarmDisplayState alarm_display_state(&state_manager, &alarm_display_view_impl, m5_time_provider, m5_time_manager);
 SettingsDisplayState settings_display_state(&settings_logic, &settings_display_view_impl);
@@ -124,6 +124,9 @@ void setup() {
     cfg.output_power = true;
     M5.begin(cfg);
     M5.Display.setTextColor(AMBER_COLOR, TFT_BLACK);
+    
+    // DateTimeAdapterの初期化
+    m5_time_provider->initializeTime();
     
     // アラームリスト初期化
     alarm_times.clear();


### PR DESCRIPTION
## 概要

`isErrorExpired()` と `showPreview` の関係で発生していた時刻取得問題を修正しました。

## 問題

- `InputDisplayState` の初期化で `timeProvider` が渡されていなかった
- 時刻取得が0になり、エラー表示が無限ループしていた
- `DateTimeAdapter` に時刻初期化機能が不足していた

## 修正内容

### 1. InputDisplayStateの初期化修正
```cpp
// 修正前
InputDisplayState input_display_state(&input_logic, &input_display_view_impl);

// 修正後
InputDisplayState input_display_state(&input_logic, &input_display_view_impl, m5_time_provider.get());
```

### 2. DateTimeAdapterの時刻初期化機能追加
```cpp
private:
    time_t baseTime = 0;
    unsigned long baseMillis = 0;

public:
    time_t now() const override { 
        time_t current = time(nullptr);
        
        // システム時刻が0の場合は、millis()ベースの時刻を使用
        if (current == 0) {
            unsigned long currentMillis = millis();
            time_t estimatedTime = baseTime + (currentMillis - baseMillis) / 1000;
            return estimatedTime;
        }
        
        return current;
    }
    
    // 起動時の初期化用
    void initializeTime() {
        baseTime = 0;
        baseMillis = millis();
    }
```

### 3. setup()での初期化呼び出し追加
```cpp
// DateTimeAdapterの初期化
m5_time_provider->initializeTime();
```

## テスト結果

- ✅ 時刻取得が正常に動作
- ✅ エラー表示の期限切れ判定が正常に機能
- ✅ システムが安定して動作
- ✅ デバッグ出力が継続的に表示

## 影響範囲

- `InputDisplayState` の時刻取得機能
- エラー表示の期限切れ判定
- システム全体の時刻管理

## 関連Issue

Closes #17