### PR TITLE
ci(automerge): gate auto-merge via labels and author_association

### DIFF
--- a/.github/workflows/pr-automerge-control.yml
+++ b/.github/workflows/pr-automerge-control.yml
@@ -1,0 +1,69 @@
+name: pr-automerge-control
+on:
+  pull_request_target:
+    types:
+      - opened
+      - reopened
+      - ready_for_review
+      - converted_to_draft
+      - labeled
+      - unlabeled
+      - edited
+      - synchronize
+
+permissions:
+  pull-requests: write
+
+jobs:
+  control-automerge:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Decide eligibility
+        id: gate
+        shell: bash
+        run: |
+          PR_DRAFT='${{ github.event.pull_request.draft }}'
+          LABELS='${{ join(github.event.pull_request.labels.*.name, ",") }}'
+          ASSOC='${{ github.event.pull_request.author_association }}'
+
+          has_label() { echo ",$LABELS," | grep -qi ",$1," ; }
+
+          eligible=true
+
+          # Draft is not eligible
+          [ "$PR_DRAFT" = "true" ] && eligible=false
+
+          # Required labels (automerge or dependencies)
+          if ! has_label automerge && ! has_label dependencies; then
+            eligible=false
+          fi
+
+          # Explicit exclusion labels
+          if has_label no-automerge || has_label hold; then
+            eligible=false
+          fi
+
+          # Exclude external contributions
+          case "$ASSOC" in
+            OWNER|MEMBER|COLLABORATOR) ;;
+            *) eligible=false ;;
+          esac
+
+          echo "eligible=$eligible" >> "$GITHUB_OUTPUT"
+
+      - name: Enable auto-merge (squash)
+        if: steps.gate.outputs.eligible == 'true'
+        uses: peter-evans/enable-pull-request-automerge@v3
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          pull-request-number: ${{ github.event.pull_request.number }}
+          merge-method: squash
+
+      - name: Disable auto-merge (if previously enabled)
+        if: steps.gate.outputs.eligible != 'true'
+        uses: peter-evans/disable-pull-request-automerge@v3
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          pull-request-number: ${{ github.event.pull_request.number }}
+
+


### PR DESCRIPTION
## 概要
公開リポジトリの安全運用のため、ラベル駆動＋`author_association`チェックにより自動マージの有効/無効を制御するWorkflowを追加します。

## 変更内容
- `.github/workflows/pr-automerge-control.yml` を追加
  - `automerge` または `dependencies` ラベルが付与され、DraftでないPRのみ対象
  - `no-automerge`/`hold` ラベルが付与された場合は対象外
  - `author_association` が `OWNER`/`MEMBER`/`COLLABORATOR` のPRのみ自動マージ有効化（外部PRは対象外）
  - 条件を満たす場合、`peter-evans/enable-pull-request-automerge@v3` でAuto-mergeを有効化（Squash）

## 運用前提
- リポジトリ設定で `Allow auto-merge` をON
- `main` のブランチ保護で必須ステータスチェックを設定
- ラベル: `automerge`, `dependencies`, `no-automerge`, `hold`

## 確認事項
- 条件変化（ラベル付与/除外、Draft→Ready、権限など）に応じて有効/無効が自動で切り替わること
- CI成功時に自動マージされること（Squash）

## 備考
- `pull_request_target` を使用しますが、コードチェックアウトや外部コマンド実行は行わず、PRメタ操作のみに限定しています。

## 参照
- #24 ビルド失敗: native 環境で unity_config.h / Arduino.h が見つからない
- #25 クイックカバレッジ計測エラー: UTF-8 デコード例外が発生
