### PR TITLE
ci: auto-merge when quality-gate passed and label hw-ok present

### DIFF
--- a/.github/workflows/quality-gate.yml
+++ b/.github/workflows/quality-gate.yml
@@ -2,8 +2,13 @@ name: Quality Gate
 
 on:
   pull_request:
-    types: [opened, synchronize, reopened, ready_for_review]
+    types: [opened, synchronize, reopened, ready_for_review, labeled]
   workflow_dispatch:
+
+# 自動マージで必要な権限（PR/ブランチ操作）
+permissions:
+  contents: write
+  pull-requests: write
 
 # 同一PRの重複実行を抑止
 concurrency:
@@ -96,3 +101,41 @@ jobs:
           fi
 
 
+  automerge:
+    name: Auto-merge when CI passed and hw-ok
+    needs: quality-gate
+    runs-on: ubuntu-latest
+    if: >
+      ${{
+        github.event_name == 'pull_request' &&
+        !github.event.pull_request.draft &&
+        contains(join(github.event.pull_request.labels.*.name, ','), 'hw-ok')
+      }}
+    steps:
+      - name: Merge PR (squash)
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const { owner, repo } = context.repo;
+            const pr = context.payload.pull_request;
+            if (!pr || pr.state !== 'open') { return; }
+            await github.pulls.merge({
+              owner,
+              repo,
+              pull_number: pr.number,
+              merge_method: 'squash'
+            });
+      - name: Delete head branch (same-repo only)
+        if: ${{ github.event.pull_request.head.repo.full_name == github.repository }}
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const { owner, repo } = context.repo;
+            const ref = 'heads/' + context.payload.pull_request.head.ref;
+            try {
+              await github.git.deleteRef({ owner, repo, ref });
+            } catch (e) {
+              core.warning(`Delete branch skipped: ${e.message}`);
+            }

--- a/.github/workflows/quality-gate.yml
+++ b/.github/workflows/quality-gate.yml
@@ -3,6 +3,8 @@ name: Quality Gate
 on:
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review, labeled]
+  pull_request_review:
+    types: [submitted]
   workflow_dispatch:
 
 # 自動マージで必要な権限（PR/ブランチ操作）
@@ -102,17 +104,16 @@ jobs:
 
 
   automerge:
-    name: Auto-merge when CI passed and hw-ok
+    name: Auto-merge when CI passed and hw-ok or approved
     needs: quality-gate
     runs-on: ubuntu-latest
     if: >
       ${{
-        github.event_name == 'pull_request' &&
-        !github.event.pull_request.draft &&
-        contains(join(github.event.pull_request.labels.*.name, ','), 'hw-ok')
+        (github.event_name == 'pull_request' || github.event_name == 'pull_request_review') &&
+        !github.event.pull_request.draft
       }}
     steps:
-      - name: Merge PR (squash)
+      - name: Merge PR (squash) when hw-ok or approved
         uses: actions/github-script@v7
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
@@ -120,7 +121,19 @@ jobs:
             const { owner, repo } = context.repo;
             const pr = context.payload.pull_request;
             if (!pr || pr.state !== 'open') { return; }
-            await github.pulls.merge({
+            const hasHwOk = Array.isArray(pr.labels) && pr.labels.some(l => l && l.name === 'hw-ok');
+            let isApproved = false;
+            try {
+              const reviews = await github.rest.pulls.listReviews({ owner, repo, pull_number: pr.number });
+              isApproved = (reviews.data || []).some(r => r && r.state === 'APPROVED');
+            } catch (e) {
+              core.warning(`listReviews failed: ${e.message}`);
+            }
+            if (!hasHwOk && !isApproved) {
+              core.info('Skip: need hw-ok label or at least one approval');
+              return;
+            }
+            await github.rest.pulls.merge({
               owner,
               repo,
               pull_number: pr.number,
@@ -135,7 +148,7 @@ jobs:
             const { owner, repo } = context.repo;
             const ref = 'heads/' + context.payload.pull_request.head.ref;
             try {
-              await github.git.deleteRef({ owner, repo, ref });
+              await github.rest.git.deleteRef({ owner, repo, ref });
             } catch (e) {
               core.warning(`Delete branch skipped: ${e.message}`);
             }

--- a/.github/workflows/quality-gate.yml
+++ b/.github/workflows/quality-gate.yml
@@ -113,7 +113,7 @@ jobs:
         !github.event.pull_request.draft
       }}
     steps:
-      - name: Merge PR (squash) when hw-ok or approved
+      - name: Merge (and delete branch on success)
         uses: actions/github-script@v7
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
@@ -121,6 +121,8 @@ jobs:
             const { owner, repo } = context.repo;
             const pr = context.payload.pull_request;
             if (!pr || pr.state !== 'open') { return; }
+
+            // 条件: hw-ok ラベル or 承認
             const hasHwOk = Array.isArray(pr.labels) && pr.labels.some(l => l && l.name === 'hw-ok');
             let isApproved = false;
             try {
@@ -133,22 +135,27 @@ jobs:
               core.info('Skip: need hw-ok label or at least one approval');
               return;
             }
-            await github.rest.pulls.merge({
-              owner,
-              repo,
-              pull_number: pr.number,
-              merge_method: 'squash'
-            });
-      - name: Delete head branch (same-repo only)
-        if: ${{ github.event.pull_request.head.repo.full_name == github.repository }}
-        uses: actions/github-script@v7
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          script: |
-            const { owner, repo } = context.repo;
-            const ref = 'heads/' + context.payload.pull_request.head.ref;
+
+            // マージ実行
+            let merged = false;
             try {
-              await github.rest.git.deleteRef({ owner, repo, ref });
+              const res = await github.rest.pulls.merge({ owner, repo, pull_number: pr.number, merge_method: 'squash' });
+              merged = !!(res && res.data && res.data.merged);
+              core.info(`merge result: ${merged}`);
             } catch (e) {
-              core.warning(`Delete branch skipped: ${e.message}`);
+              core.warning(`Merge failed: ${e.message}`);
+            }
+
+            // 成功時のみブランチ削除（同一リポジトリに限る）
+            if (merged) {
+              const sameRepo = pr.head && pr.head.repo && (pr.head.repo.full_name === `${owner}/${repo}`);
+              if (sameRepo) {
+                const ref = 'heads/' + pr.head.ref;
+                try {
+                  await github.rest.git.deleteRef({ owner, repo, ref });
+                  core.info(`Deleted branch ${ref}`);
+                } catch (e) {
+                  core.warning(`Delete branch skipped: ${e.message}`);
+                }
+              }
             }


### PR DESCRIPTION
## 概要
quality-gate 合格かつ hw-ok または 1承認で自動マージ（squash）。

## 変更点
- permissions 追加（contents: write / pull-requests: write）
- pull_request_review(submitted) をトリガーに追加
- automerge 条件を hw-ok または 承認 に変更（quality-gateは常に必須）
- github-script のAPIを github.rest.pulls.merge / github.rest.git.deleteRef に修正

## 運用
- src/ 配下に変更がないPR: Approveで自動マージ（実機不要）
- src/ を含むPR: 実機OKなら hw-ok を付与で自動マージ（Approve不要）
- Draft PRは対象外

## 確認項目
- [ ] quality-gate が green + hw-ok で自動マージ
- [ ] quality-gate が green + 1承認 で自動マージ
- [ ] マージ後、同一リポジトリのヘッドブランチを削除

## 注意
- ブランチ保護: main に quality-gate を必須チェックとして適用済み
- Approveはブランチ保護の必須条件ではありません（自動マージ条件の一部）
