### PR TITLE
chore(design): TIME SYNC (QR) 設計追記と表示名置換（SET DATE/TIME → TIME SYNC） [AIM-43]

### DIFF
--- a/doc/design/ui_state_management.md
+++ b/doc/design/ui_state_management.md
@@ -126,4 +126,27 @@ public:
 
 ---
 
-（2025/01/xx 3-0-4対応 追記） 
+（2025/01/xx 3-0-4対応 追記）
+
+## TIME SYNC (QR)
+
+- Entry: `SETTINGS_MENU` → select "TIME SYNC"
+- Exit:
+  - success → `MAIN_DISPLAY`
+  - cancel/timeout → `SETTINGS_MENU`
+- Buttons: A = REISSUE, C = EXIT（Bは未使用）
+- Tick policy: `TimeSyncDisplayState.onDraw()` 内で `ITimeSyncController.loopTick()` を毎フレーム呼ぶ（約20Hz）
+
+```mermaid
+stateDiagram-v2
+  [*] --> SETTINGS_MENU
+  SETTINGS_MENU --> TIME_SYNC: select "TIME SYNC"
+  TIME_SYNC --> MAIN_DISPLAY: synced (success)
+  TIME_SYNC --> SETTINGS_MENU: exit (C) / timeout
+```
+
+Call flow (proposal A):
+```
+loop() → StateManager.getCurrentState() → onDraw()
+  → TimeSyncDisplayState.onDraw() → controller.loopTick() → view更新
+```

--- a/lib/libaimatix/src/SettingsLogic.h
+++ b/lib/libaimatix/src/SettingsLogic.h
@@ -121,7 +121,7 @@ inline auto SettingsLogic::getItemDisplayName(SettingsItem item) const -> std::s
     switch (item) {
         case SettingsItem::SOUND: return "SOUND";
         case SettingsItem::LCD_BRIGHTNESS: return "LCD BRIGHTNESS";
-        case SettingsItem::SET_DATE_TIME: return "SET DATE/TIME";
+        case SettingsItem::SET_DATE_TIME: return "TIME SYNC";
         case SettingsItem::INFO: return "INFO";
         default: return "UNKNOWN";
     }

--- a/test/pure/test_settings_display_pure/test_main.cpp
+++ b/test/pure/test_settings_display_pure/test_main.cpp
@@ -216,7 +216,7 @@ void test_settings_logic_branch_coverage() {
     // getItemDisplayNameの全分岐テスト
     TEST_ASSERT_EQUAL_STRING("SOUND", logic.getItemDisplayName(SettingsItem::SOUND).c_str());
     TEST_ASSERT_EQUAL_STRING("LCD BRIGHTNESS", logic.getItemDisplayName(SettingsItem::LCD_BRIGHTNESS).c_str());
-    TEST_ASSERT_EQUAL_STRING("SET DATE/TIME", logic.getItemDisplayName(SettingsItem::SET_DATE_TIME).c_str());
+    TEST_ASSERT_EQUAL_STRING("TIME SYNC", logic.getItemDisplayName(SettingsItem::SET_DATE_TIME).c_str());
     
     // getItemValueStringの全分岐テスト
     std::string soundValue = logic.getItemValueString(SettingsItem::SOUND);


### PR DESCRIPTION
## 概要
設定メニューの `SET DATE/TIME` を `TIME SYNC` に置換し、導線と遷移図（Mermaid）を設計ドキュメントへ追記しました。

## 変更内容
- 設計: `doc/design/ui_state_management.md` に「TIME SYNC (QR)」節を追加
  - 遷移図（Mermaid）
  - Tick方針: `TimeSyncDisplayState.onDraw()` 内で `ITimeSyncController.loopTick()` を毎フレーム呼ぶ
  - 戻り先: 成功→`MAIN_DISPLAY`、キャンセル/タイムアウト→`SETTINGS_MENU`
  - ボタン: A=REISSUE, C=EXIT
- 表示名: `lib/libaimatix/src/SettingsLogic.h` の `SET DATE/TIME` を `TIME SYNC` に変更
- テスト: `test/pure/test_settings_display_pure/test_main.cpp` の期待値を `TIME SYNC` に更新

## テスト/品質
- `pio run` 成功
- `pio test -e native` 成功（226/226）
- `python scripts/test_coverage.py --quick` 成功（81.5% >= 80% 必須）

## 受け入れ条件（DoD）
- 設定メニューの情報設計が確定し、遷移図が文書化されている
- `doc/design/ui_state_management.md` に反映済み
- PRで `pio run` → `pio test -e native` → `python scripts/test_coverage.py --quick` を通過

## 参照
- Linear: AIM-43（GitHub Issue #66 と同期）
- PoC: `doc/design/softap_qr_time_sync_poc.md`

Closes #66