### PR TITLE
chore(design): TIME SYNC (QR) 起動時自動開始の抑止/設定非露出を追記（AIM-37, #68）

### DIFF
--- a/doc/design/ui_state_management.md
+++ b/doc/design/ui_state_management.md
@@ -139,6 +139,8 @@ public:
 - Tick policy: `TimeSyncDisplayState.onDraw()` 内で `ITimeSyncController.loopTick()` を毎フレーム呼ぶ（約20Hz）
 - Sync method: SoftAP + QR のみ（本起動時自動同期では NTP 自動同期は使用しない）
 - Dialog policy: 提案ダイアログは表示しない（自動開始）
+ - Boot auto suppression: 本起動中にユーザーが `EXIT` を実行した場合は、同一起動内では再自動開始しない（抑止）。次回起動時に再評価し、引き続き無効時刻であれば自動開始する。
+ - Settings policy: 本ポリシーは設定として露出しない（`BOOT TIME SYNC: AUTO/ASK/NEVER` 等のメニューは提供しない）。
 
 ```mermaid
 stateDiagram-v2


### PR DESCRIPTION
## 概要
- TIME SYNC (QR) の起動時自動開始ポリシーを明文化
- 本起動中に EXIT した場合の再自動開始“抑止”と、次回起動時の再評価を追記
- 当該ポリシーは設定として露出しない（設定メニューの追加は行わない）ことを明記

## 変更内容
- `doc/design/ui_state_management.md`: 「TIME SYNC (QR)」節に下記を追記
  - Boot auto suppression: 本起動中にユーザーが `EXIT` を実行した場合は、同一起動内では再自動開始しない。次回起動で再評価
  - Settings policy: ポリシーは設定として露出しない（`BOOT TIME SYNC: AUTO/ASK/NEVER` 等のメニューは提供しない）

## DoD
- 既定方針と将来の設定化可否（文言含む）を文書化
- #68 で合意済みの仕様へ反映

## テスト・品質
- ドキュメントのみの変更（機能・ビルドへの影響なし）
- 既存のビルド/テストは影響なし

## 参照
- Issue: #68 / #66 / #67
- 設計: `doc/design/ui_state_management.md`, `doc/design/softap_qr_time_sync_poc.md`

Closes #68