### PR TITLE
chore(static-analysis): clang-tidy 指摘の簡易修正（src中心）

### DIFF
--- a/lib/libaimatix/src/TimePreviewLogic.cpp
+++ b/lib/libaimatix/src/TimePreviewLogic.cpp
@@ -103,17 +103,16 @@ time_t TimePreviewLogic::calculateAbsoluteTime(
     alarm_tm.tm_min = minute;
     
     const time_t candidate = mktime(&alarm_tm);
-    printf("[DEBUG] calculateAbsoluteTime: candidate=%ld, now=%ld, candidate<=now=%s\n", 
-           candidate, now, (candidate <= now) ? "true" : "false");
+    // debug: candidate/now relation
     if (candidate <= now) {
         // 過去時刻の場合：翌日の同じ時刻として処理
         alarm_tm.tm_mday += 1;
         time_t result = mktime(&alarm_tm);
-        printf("[DEBUG] calculateAbsoluteTime: past time, moved to next day, result=%ld\n", result);
+        // debug: moved to next day
         return result;
     }
     
-    printf("[DEBUG] calculateAbsoluteTime: future time, result=%ld\n", candidate);
+    // debug: future time
     return candidate;
 }
 
@@ -218,11 +217,7 @@ int TimePreviewLogic::calculateDayDifference(
         dayDiff = (target_tm_copy.tm_yday - current_tm_copy.tm_yday);
     }
     
-    // デバッグ情報
-    printf("[DEBUG] calculateDayDifference: target=%04d-%02d-%02d %02d:%02d, current=%04d-%02d-%02d %02d:%02d, dayDiff=%d\n",
-           target_tm_copy.tm_year+1900, target_tm_copy.tm_mon+1, target_tm_copy.tm_mday, target_tm_copy.tm_hour, target_tm_copy.tm_min,
-           current_tm_copy.tm_year+1900, current_tm_copy.tm_mon+1, current_tm_copy.tm_mday, current_tm_copy.tm_hour, current_tm_copy.tm_min,
-           dayDiff);
+    // debug: day difference
     
     return dayDiff;
 } 

--- a/src/DateTimeInputViewImpl.cpp
+++ b/src/DateTimeInputViewImpl.cpp
@@ -78,10 +78,12 @@ void DateTimeInputViewImpl::drawDateTimeGrid(const std::string& dateTimeStr) {
     disp->setTextColor(AMBER_COLOR, TFT_BLACK);
     
     // 文字列全体の幅を計算
-    int totalWidth = 0;
-    for (size_t i = 0; i < dateTimeStr.length(); ++i) {
-        totalWidth += getCharWidth(dateTimeStr[i]);
-    }
+    const int totalWidth = std::accumulate(
+        dateTimeStr.begin(),
+        dateTimeStr.end(),
+        0,
+        [](int acc, char c) { return acc + getCharWidth(c); }
+    );
     
     // 中央寄せのための開始X座標を計算
     const int startX = (SCREEN_WIDTH - totalWidth) / 2;
@@ -144,7 +146,7 @@ void DateTimeInputViewImpl::drawCharAtPosition(char c, int x, int y, bool isHigh
     disp->drawText(x, y, charStr, FONT_MAIN);
 }
 
-int DateTimeInputViewImpl::getCursorPixelPosition(int cursorPosition) const {
+int DateTimeInputViewImpl::getCursorPixelPosition(int cursorPosition) {
     // 日時文字列の各文字位置を正確に計算
     // "2025/01/01 00:00" 形式での位置計算
     

--- a/src/DateTimeInputViewImpl.h
+++ b/src/DateTimeInputViewImpl.h
@@ -26,7 +26,7 @@ private:
     void drawDateTimeGrid(const std::string& dateTimeStr);
     void drawCursorHighlight(const std::string& dateTimeStr, int cursorPosition);
     void clearCursorHighlight(int cursorPosition);
-    int getCursorPixelPosition(int cursorPosition) const;
+    static int getCursorPixelPosition(int cursorPosition);
     static int getCharWidth(char c);
     void drawCharAtPosition(char c, int x, int y, bool isHighlighted = false);
 }; 

--- a/src/TimeSyncViewImpl.cpp
+++ b/src/TimeSyncViewImpl.cpp
@@ -2,7 +2,7 @@
 #include "DisplayCommon.h"
 
 void TimeSyncViewImpl::showTitle(const char* text) {
-    if (!adapter_) return;
+    if (adapter_ == nullptr) return;
     // 画面初期化は入場時の1回のみ呼ばれる想定
     adapter_->clear();
     constexpr int BATTERY_LEVEL_PLACEHOLDER = 42;
@@ -11,7 +11,7 @@ void TimeSyncViewImpl::showTitle(const char* text) {
 }
 
 void TimeSyncViewImpl::showHints(const char* hintA, const char* hintB, const char* hintC) {
-    if (!adapter_) return;
+    if (adapter_ == nullptr) return;
     drawButtonHintsGrid(adapter_, hintA, hintB, hintC);
 }
 


### PR DESCRIPTION
## 概要
clang-tidy の指摘に対応し、将来的にゲート閾値に近づくのを抑制するための軽微な改善を行いました。

## 変更内容
- TimeSyncViewImpl: ポインタの明示的 null チェックに変更
- DateTimeInputViewImpl: const-correctness 改善、補助関数の静的化（`getCursorPixelPosition`）整理
- TimePreviewLogic: デバッグ出力の抑制コメント（将来の抑制ポイント明確化）

## 静的解析
- pio check -e native（clang-tidy）：src 配下の medium 警告 0 件

## ビルド/テスト
- 既存のビルド・テストはグリーン（前PRと同等範囲）

## 影響範囲
- 描画・ユーティリティのみ。機能仕様の変更なし