### PR TITLE
feat: AIM-48 Step1 SoftAP起動/停止＋Wi‑Fi QR（MVP2）

### DIFF
--- a/lib/libaimatix/src/ITimeSyncController.h
+++ b/lib/libaimatix/src/ITimeSyncController.h
@@ -1,0 +1,26 @@
+#pragma once
+
+#include <string>
+
+// Abstract controller interface for SoftAP Time Sync (Step1 scope).
+class ITimeSyncController {
+public:
+    virtual ~ITimeSyncController() {}
+
+    // Start SoftAP and prepare credentials (SSID/PSK/token)
+    virtual void begin() = 0;
+
+    // Stop SoftAP
+    virtual void cancel() = 0;
+
+    // Periodic tick from UI (~20Hz). May be no-op in Step1.
+    virtual void loopTick() = 0;
+
+    // Reissue credentials (new SSID/PSK/token). Should not restart AP if unnecessary.
+    virtual void reissue() = 0;
+
+    // Get current SSID and PSK (Step1 scope). Implementations copy to outputs.
+    virtual void getCredentials(std::string& outSsid, std::string& outPsk) const = 0;
+};
+
+

--- a/lib/libaimatix/src/ITimeSyncView.h
+++ b/lib/libaimatix/src/ITimeSyncView.h
@@ -11,6 +11,9 @@ public:
 
     // Three-slot button hints (A/B/C). Empty string allowed for unused slot.
     virtual void showHints(const char* hintA, const char* hintB, const char* hintC) = 0;
+
+    // Draw Wi‑Fi QR payload (e.g., WIFI:T:WPA;S:...;P:...;H:false;;)
+    virtual void showWifiQr(const char* payload) = 0;
 };
 
 

--- a/lib/libaimatix/src/TimeSyncCore.cpp
+++ b/lib/libaimatix/src/TimeSyncCore.cpp
@@ -1,0 +1,41 @@
+#include "TimeSyncCore.h"
+
+namespace {
+static std::string escapeForWifiField(const std::string& input) {
+    std::string out;
+    out.reserve(input.size() * 2);
+    for (char c : input) {
+        switch (c) {
+            case '\\':
+            case ';':
+            case ',':
+            case ':':
+                out.push_back('\\');
+                out.push_back(c);
+                break;
+            default:
+                out.push_back(c);
+        }
+    }
+    return out;
+}
+}
+
+namespace TimeSyncCore {
+
+std::string buildWifiQrPayload(const std::string& ssid, const std::string& psk) {
+    const std::string escSsid = escapeForWifiField(ssid);
+    const std::string escPsk  = escapeForWifiField(psk);
+    std::string payload;
+    payload.reserve(32 + escSsid.size() + escPsk.size());
+    payload += "WIFI:T:WPA;S:";
+    payload += escSsid;
+    payload += ";P:";
+    payload += escPsk;
+    payload += ";H:false;;";
+    return payload;
+}
+
+}
+
+

--- a/lib/libaimatix/src/TimeSyncCore.h
+++ b/lib/libaimatix/src/TimeSyncCore.h
@@ -1,0 +1,15 @@
+#pragma once
+
+#include <string>
+
+// Utility for building Wi‑Fi QR payloads used in Time Sync step1.
+// Format (PoC準拠): "WIFI:T:WPA;S:<SSID>;P:<PSK>;H:false;;"
+// Escape rules: in SSID/PSK, characters \\ ; , : must be escaped with a preceding backslash.
+namespace TimeSyncCore {
+
+// Build Wi‑Fi QR payload from SSID and PSK with proper escaping.
+std::string buildWifiQrPayload(const std::string& ssid, const std::string& psk);
+
+}
+
+

--- a/lib/libaimatix/src/TimeSyncDisplayState.h
+++ b/lib/libaimatix/src/TimeSyncDisplayState.h
@@ -1,24 +1,40 @@
 #pragma once
 #include "StateManager.h"
 #include "ITimeSyncView.h"
+#include "ITimeSyncController.h"
+#include "TimeSyncCore.h"
+#include <string>
 
 // Minimal MVP1 state: draws static title/hints and exits to settings on C short press.
 class TimeSyncDisplayState : public IState {
 public:
-    TimeSyncDisplayState(ITimeSyncView* view = nullptr)
-        : manager(nullptr), settingsDisplayState(nullptr), view(view) {}
+    TimeSyncDisplayState(ITimeSyncView* view = nullptr, ITimeSyncController* controller = nullptr)
+        : manager(nullptr), settingsDisplayState(nullptr), view(view), controller(controller) {}
 
     void setManager(StateManager* m) { manager = m; }
     void setSettingsDisplayState(IState* st) { settingsDisplayState = st; }
     void setView(ITimeSyncView* v) { view = v; }
+    void setController(ITimeSyncController* c) { controller = c; }
 
-    void onEnter() override { drawStatic(); }
+    void onEnter() override { drawStep1(); }
     void onExit() override {}
-    void onDraw() override { /* draw only once on enter to avoid flicker */ }
-    void onButtonA() override { /* REISSUE reserved for later MVPs */ }
+    void onDraw() override {
+        if (controller) controller->loopTick();
+        /* no redraw to avoid flicker */
+    }
+    void onButtonA() override {
+        if (controller) {
+            controller->reissue();
+            std::string ssid, psk;
+            controller->getCredentials(ssid, psk);
+            const std::string payload = TimeSyncCore::buildWifiQrPayload(ssid, psk);
+            if (view) view->showWifiQr(payload.c_str());
+        }
+    }
     void onButtonB() override { /* unused */ }
     void onButtonC() override {
         // EXIT → SETTINGS_MENU
+        if (controller) controller->cancel();
         if (manager != nullptr && settingsDisplayState != nullptr) {
             manager->setState(settingsDisplayState);
         }
@@ -28,16 +44,24 @@ public:
     void onButtonCLongPress() override { /* unassigned */ }
 
 private:
-    void drawStatic() {
+    void drawStep1() {
         if (view) {
             view->showTitle("TIME SYNC > JOIN AP");
             view->showHints("REISSUE", "", "EXIT");
+        }
+        if (controller && view) {
+            controller->begin();
+            std::string ssid, psk;
+            controller->getCredentials(ssid, psk);
+            const std::string payload = TimeSyncCore::buildWifiQrPayload(ssid, psk);
+            view->showWifiQr(payload.c_str());
         }
     }
 
     StateManager* manager;
     IState* settingsDisplayState;
     ITimeSyncView* view;
+    ITimeSyncController* controller;
 };
 
 

--- a/platformio.ini
+++ b/platformio.ini
@@ -19,6 +19,7 @@ framework = arduino
 lib_deps =
     m5stack/M5Unified @ ^0.2.7
     m5stack/M5GFX @ ^0.2.8
+    ricmoo/QRCode @ ^0.0.1
 monitor_speed = 115200
 upload_speed = 1500000  ; Fire v2.7も同じチップのため統一
 build_type = release

--- a/src/DateTimeInputViewImpl.cpp
+++ b/src/DateTimeInputViewImpl.cpp
@@ -2,6 +2,7 @@
 #include "ui_constants.h"
 #include <cstring>
 #include <string>
+#include <numeric>
 #ifdef ARDUINO
 #include <Arduino.h>
 #endif

--- a/src/SoftApTimeSyncController.cpp
+++ b/src/SoftApTimeSyncController.cpp
@@ -1,0 +1,81 @@
+#include "SoftApTimeSyncController.h"
+
+#ifdef ARDUINO
+#include <Arduino.h>
+#include <WiFi.h>
+#endif
+
+#include <stdint.h>
+
+namespace {
+static uint64_t simpleRand64() {
+    // 非暗号用の簡易生成（Step1暫定: PoC準拠64bit相当）
+    uint64_t x = 1469598103934665603ull;
+    x ^= (uint64_t)millis();
+    x *= 1099511628211ull;
+    x ^= (uint64_t)micros();
+    x *= 1099511628211ull;
+    return x;
+}
+
+static std::string toHex64(uint64_t v) {
+    static const char* hex = "0123456789abcdef";
+    std::string s(16, '0');
+    for (int i = 15; i >= 0; --i) {
+        s[i] = hex[v & 0xF];
+        v >>= 4;
+    }
+    return s;
+}
+}
+
+SoftApTimeSyncController::SoftApTimeSyncController()
+    : running_(false) {}
+
+void SoftApTimeSyncController::generateCredentials() {
+    const uint64_t r1 = simpleRand64();
+    const uint64_t r2 = simpleRand64();
+    const uint64_t r3 = simpleRand64();
+    ssid_  = std::string("AIM-TS-") + toHex64(r1).substr(0, 8);
+    psk_   = toHex64(r2).substr(0, 16);
+    token_ = toHex64(r3).substr(0, 16);
+}
+
+void SoftApTimeSyncController::begin() {
+    generateCredentials();
+#ifdef ARDUINO
+    WiFi.mode(WIFI_AP);
+    // PSKは最低8文字必要
+    WiFi.softAP(ssid_.c_str(), psk_.c_str());
+#endif
+    running_ = true;
+}
+
+void SoftApTimeSyncController::cancel() {
+#ifdef ARDUINO
+    WiFi.softAPdisconnect(true);
+    WiFi.mode(WIFI_OFF);
+#endif
+    running_ = false;
+}
+
+void SoftApTimeSyncController::loopTick() {
+    // Step1では特に行うことなし（将来、クライアント接続検出等）
+}
+
+void SoftApTimeSyncController::reissue() {
+    generateCredentials();
+#ifdef ARDUINO
+    if (running_) {
+        WiFi.softAPdisconnect(true);
+        WiFi.softAP(ssid_.c_str(), psk_.c_str());
+    }
+#endif
+}
+
+void SoftApTimeSyncController::getCredentials(std::string& outSsid, std::string& outPsk) const {
+    outSsid = ssid_;
+    outPsk = psk_;
+}
+
+

--- a/src/SoftApTimeSyncController.h
+++ b/src/SoftApTimeSyncController.h
@@ -1,0 +1,28 @@
+#pragma once
+
+#include "ITimeSyncController.h"
+#include <string>
+
+// SoftAP controller for ESP32 (Step1 scope: Wi‑Fi QR only)
+class SoftApTimeSyncController : public ITimeSyncController {
+public:
+    SoftApTimeSyncController();
+
+    void begin() override;
+    void cancel() override;
+    void loopTick() override;
+    void reissue() override;
+
+    void getCredentials(std::string& outSsid, std::string& outPsk) const override;
+
+private:
+    void generateCredentials();
+
+    std::string ssid_;
+    std::string psk_;
+    std::string token_;
+
+    bool running_;
+};
+
+

--- a/src/TimeSyncViewImpl.cpp
+++ b/src/TimeSyncViewImpl.cpp
@@ -1,5 +1,14 @@
 #include "TimeSyncViewImpl.h"
 #include "DisplayCommon.h"
+#include <string>
+#include <algorithm>
+#ifdef ARDUINO
+#include <M5Unified.h>
+extern "C" {
+#include <qrcode.h>
+}
+#endif
+// QR表示は仕様通り ricmoo/QRCode + M5GFX を用いるが、実装詳細は Adapter 経由へ委譲可能性あり。
 
 void TimeSyncViewImpl::showTitle(const char* text) {
     if (adapter_ == nullptr) return;
@@ -13,6 +22,59 @@ void TimeSyncViewImpl::showTitle(const char* text) {
 void TimeSyncViewImpl::showHints(const char* hintA, const char* hintB, const char* hintC) {
     if (adapter_ == nullptr) return;
     drawButtonHintsGrid(adapter_, hintA, hintB, hintC);
+}
+
+void TimeSyncViewImpl::showWifiQr(const char* payload) {
+    if (adapter_ == nullptr || payload == nullptr) return;
+    // 仕様: ECC LOW, quiet zone=2, 上余白10px, 黒背景/アンバードット
+    // 現時点では DisplayAdapter にQR APIが無いため、ここで直接描画する。
+    // 実装を後で Adapter へ移譲可能。
+
+    // タイトルバーの下にQRを配置するため上部に余白
+    const int topMargin = 10;
+
+#ifdef ARDUINO
+    QRCode qrcode;
+    // サイズ決定（Wi‑Fi文字列は比較的長め。version 7目安）
+    const uint8_t version = 7;
+    const uint8_t ecc = 0; // ECC_LOW
+    const size_t qrSize = qrcode_getBufferSize(version);
+    uint8_t* qrcodeData = (uint8_t*)malloc(qrSize);
+    if (!qrcodeData) return;
+    if (qrcode_initText(&qrcode, qrcodeData, version, ecc, payload) != 0) {
+        free(qrcodeData);
+        return;
+    }
+    const int moduleCount = qrcode.size;
+    const int quietZone = 2;
+    // 最大スケールを計算（画面幅・高さから算出）
+    const int screenW = M5.Display.width();
+    const int screenH = M5.Display.height();
+    const int availableH = screenH - topMargin;
+    const int maxModules = moduleCount + quietZone * 2;
+    const int scale = std::max(1, std::min(screenW / maxModules, availableH / maxModules));
+    const int qrW = maxModules * scale;
+    const int startX = (screenW - qrW) / 2;
+    const int startY = topMargin + (availableH - qrW) / 2;
+
+    // 背景クリア（タイトルバーは保持）
+    M5.Display.fillRect(0, topMargin, screenW, availableH, TFT_BLACK);
+
+    // 描画
+    for (int y = 0; y < moduleCount; y++) {
+        for (int x = 0; x < moduleCount; x++) {
+            const bool dot = qrcode_getModule(&qrcode, x, y);
+            const int px = startX + (x + quietZone) * scale;
+            const int py = startY + (y + quietZone) * scale;
+            if (dot) {
+                M5.Display.fillRect(px, py, scale, scale, AMBER_COLOR);
+            }
+        }
+    }
+    free(qrcodeData);
+#else
+    (void)payload;
+#endif
 }
 
 

--- a/src/TimeSyncViewImpl.h
+++ b/src/TimeSyncViewImpl.h
@@ -3,6 +3,7 @@
 #include "ITimeSyncView.h"
 #include "DisplayAdapter.h"
 #include "ui_constants.h"
+#include <string>
 
 // Hardware-dependent implementation of ITimeSyncView for M5Stack devices.
 class TimeSyncViewImpl : public ITimeSyncView {
@@ -11,6 +12,7 @@ public:
 
     void showTitle(const char* text) override;
     void showHints(const char* hintA, const char* hintB, const char* hintC) override;
+    void showWifiQr(const char* payload) override;
 
 private:
     DisplayAdapter* adapter_;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -19,6 +19,7 @@
 #include "ButtonManager.h"
 #include "TimeSyncDisplayState.h"
 #include "TimeSyncViewImpl.h"
+#include "SoftApTimeSyncController.h"
 
 // 共通include（全環境で使用）
 #include <Arduino.h>
@@ -107,8 +108,9 @@ InputDisplayState input_display_state(&input_logic, &input_display_view_impl, m5
 MainDisplayState main_display_state(&state_manager, &input_display_state, &main_display_view_impl, &time_logic, &alarm_logic);
 AlarmDisplayState alarm_display_state(&state_manager, &alarm_display_view_impl, m5_time_provider, m5_time_manager);
 SettingsDisplayState settings_display_state(&settings_logic, &settings_display_view_impl);
-TimeSyncViewImpl time_sync_view_impl(&display_adapter);
-TimeSyncDisplayState time_sync_display_state(&time_sync_view_impl);
+ TimeSyncViewImpl time_sync_view_impl(&display_adapter);
+ SoftApTimeSyncController time_sync_controller;
+ TimeSyncDisplayState time_sync_display_state(&time_sync_view_impl, &time_sync_controller);
 DateTimeInputState datetime_input_state(m5_time_provider.get(), &datetime_input_view_impl);
 #else
 // Native環境用のモック（テスト用）

--- a/test/mock/MockTimeSyncController.h
+++ b/test/mock/MockTimeSyncController.h
@@ -1,0 +1,29 @@
+#pragma once
+
+#include "ITimeSyncController.h"
+#include <string>
+
+class MockTimeSyncController : public ITimeSyncController {
+public:
+    void begin() override { beginCount++; }
+    void cancel() override { cancelCount++; }
+    void loopTick() override { loopTickCount++; }
+    void reissue() override { reissueCount++; ssid = reissueSsid; psk = reissuePsk; }
+
+    void getCredentials(std::string& outSsid, std::string& outPsk) const override { outSsid = ssid; outPsk = psk; }
+
+    void setInitialCredentials(const std::string& s, const std::string& p) { ssid = s; psk = p; }
+    void setReissueCredentials(const std::string& s, const std::string& p) { reissueSsid = s; reissuePsk = p; }
+
+    int beginCount{0};
+    int cancelCount{0};
+    int loopTickCount{0};
+    int reissueCount{0};
+
+    std::string ssid;
+    std::string psk;
+    std::string reissueSsid;
+    std::string reissuePsk;
+};
+
+

--- a/test/mock/MockTimeSyncView.h
+++ b/test/mock/MockTimeSyncView.h
@@ -11,11 +11,14 @@ public:
         lastHintC = c ? c : "";
         calledShowHints = true;
     }
+    void showWifiQr(const char* payload) override { lastWifiQr = payload ? payload : ""; calledShowWifiQr = true; }
 
     std::string lastTitle;
     std::string lastHintA, lastHintB, lastHintC;
+    std::string lastWifiQr;
     bool calledShowTitle{false};
     bool calledShowHints{false};
+    bool calledShowWifiQr{false};
 };
 
 

--- a/test/pure/test_time_sync_core_pure/test_main.cpp
+++ b/test/pure/test_time_sync_core_pure/test_main.cpp
@@ -1,0 +1,55 @@
+#include <unity.h>
+#include "TimeSyncCore.h"
+#include <string>
+
+void setUp() {}
+void tearDown() {}
+
+void test_build_wifi_qr_payload_basic() {
+    auto s = TimeSyncCore::buildWifiQrPayload("SSID", "PSK");
+    TEST_ASSERT_EQUAL_STRING("WIFI:T:WPA;S:SSID;P:PSK;H:false;;", s.c_str());
+}
+
+void test_build_wifi_qr_payload_escape_backslash() {
+    auto s = TimeSyncCore::buildWifiQrPayload("SS\\ID", "P\\SK");
+    TEST_ASSERT_EQUAL_STRING("WIFI:T:WPA;S:SS\\\\ID;P:P\\\\SK;H:false;;", s.c_str());
+}
+
+void test_build_wifi_qr_payload_escape_semicolon() {
+    auto s = TimeSyncCore::buildWifiQrPayload("SS;ID", "P;SK");
+    TEST_ASSERT_EQUAL_STRING("WIFI:T:WPA;S:SS\\;ID;P:P\\;SK;H:false;;", s.c_str());
+}
+
+void test_build_wifi_qr_payload_escape_comma() {
+    auto s = TimeSyncCore::buildWifiQrPayload("SS,ID", ",PSK");
+    TEST_ASSERT_EQUAL_STRING("WIFI:T:WPA;S:SS\\,ID;P:\\,PSK;H:false;;", s.c_str());
+}
+
+void test_build_wifi_qr_payload_escape_colon() {
+    auto s = TimeSyncCore::buildWifiQrPayload("SS:ID", "PS:K");
+    TEST_ASSERT_EQUAL_STRING("WIFI:T:WPA;S:SS\\:ID;P:PS\\:K;H:false;;", s.c_str());
+}
+
+void test_build_wifi_qr_payload_empty_ssid() {
+    auto s = TimeSyncCore::buildWifiQrPayload("", "PSK");
+    TEST_ASSERT_EQUAL_STRING("WIFI:T:WPA;S:;P:PSK;H:false;;", s.c_str());
+}
+
+void test_build_wifi_qr_payload_empty_psk() {
+    auto s = TimeSyncCore::buildWifiQrPayload("SSID", "");
+    TEST_ASSERT_EQUAL_STRING("WIFI:T:WPA;S:SSID;P:;H:false;;", s.c_str());
+}
+
+int main() {
+    UNITY_BEGIN();
+    RUN_TEST(test_build_wifi_qr_payload_basic);
+    RUN_TEST(test_build_wifi_qr_payload_escape_backslash);
+    RUN_TEST(test_build_wifi_qr_payload_escape_semicolon);
+    RUN_TEST(test_build_wifi_qr_payload_escape_comma);
+    RUN_TEST(test_build_wifi_qr_payload_escape_colon);
+    RUN_TEST(test_build_wifi_qr_payload_empty_ssid);
+    RUN_TEST(test_build_wifi_qr_payload_empty_psk);
+    return UNITY_END();
+}
+
+

--- a/test/pure/test_time_sync_display_pure/test_main.cpp
+++ b/test/pure/test_time_sync_display_pure/test_main.cpp
@@ -1,6 +1,8 @@
 #include <unity.h>
 #include "TimeSyncDisplayState.h"
 #include "../mock/MockTimeSyncView.h"
+#include "../mock/MockTimeSyncController.h"
+#include <string>
 
 class DummySettingsState : public IState {
 public:
@@ -66,6 +68,110 @@ void test_time_sync_on_draw_does_not_redraw_hints() {
     TEST_ASSERT_FALSE(view.calledShowHints);
 }
 
+// --- New tests for controller integration (Step1) ---
+
+void test_time_sync_on_enter_calls_begin_once() {
+    MockTimeSyncView view;
+    MockTimeSyncController controller;
+    controller.setInitialCredentials("SSID", "PSK");
+    TimeSyncDisplayState state(&view, &controller);
+    state.onEnter();
+    TEST_ASSERT_EQUAL(1, controller.beginCount);
+}
+
+void test_time_sync_on_enter_shows_wifi_qr_called() {
+    MockTimeSyncView view;
+    MockTimeSyncController controller;
+    controller.setInitialCredentials("SSID", "PSK");
+    TimeSyncDisplayState state(&view, &controller);
+    state.onEnter();
+    TEST_ASSERT_TRUE(view.calledShowWifiQr);
+}
+
+void test_time_sync_on_enter_shows_wifi_qr_payload_exact() {
+    MockTimeSyncView view;
+    MockTimeSyncController controller;
+    controller.setInitialCredentials("SSID", "PSK");
+    TimeSyncDisplayState state(&view, &controller);
+    state.onEnter();
+    TEST_ASSERT_EQUAL_STRING("WIFI:T:WPA;S:SSID;P:PSK;H:false;;", view.lastWifiQr.c_str());
+}
+
+void test_time_sync_on_draw_calls_loop_tick_once() {
+    MockTimeSyncView view;
+    MockTimeSyncController controller;
+    controller.setInitialCredentials("SSID", "PSK");
+    TimeSyncDisplayState state(&view, &controller);
+    state.onEnter();
+    controller.loopTickCount = 0;
+    state.onDraw();
+    TEST_ASSERT_EQUAL(1, controller.loopTickCount);
+}
+
+void test_time_sync_on_draw_does_not_redraw_qr() {
+    MockTimeSyncView view;
+    MockTimeSyncController controller;
+    controller.setInitialCredentials("SSID", "PSK");
+    TimeSyncDisplayState state(&view, &controller);
+    state.onEnter();
+    view.calledShowWifiQr = false;
+    state.onDraw();
+    TEST_ASSERT_FALSE(view.calledShowWifiQr);
+}
+
+void test_time_sync_button_a_calls_reissue_once() {
+    MockTimeSyncView view;
+    MockTimeSyncController controller;
+    controller.setInitialCredentials("S1", "P1");
+    controller.setReissueCredentials("S2", "P2");
+    TimeSyncDisplayState state(&view, &controller);
+    state.onEnter();
+    controller.reissueCount = 0;
+    state.onButtonA();
+    TEST_ASSERT_EQUAL(1, controller.reissueCount);
+}
+
+void test_time_sync_button_a_updates_qr_payload() {
+    MockTimeSyncView view;
+    MockTimeSyncController controller;
+    controller.setInitialCredentials("S1", "P1");
+    controller.setReissueCredentials("S2", "P2");
+    TimeSyncDisplayState state(&view, &controller);
+    state.onEnter();
+    view.calledShowWifiQr = false;
+    state.onButtonA();
+    TEST_ASSERT_EQUAL_STRING("WIFI:T:WPA;S:S2;P:P2;H:false;;", view.lastWifiQr.c_str());
+}
+
+void test_time_sync_button_c_calls_cancel_once() {
+    StateManager manager;
+    MockTimeSyncView view;
+    MockTimeSyncController controller;
+    controller.setInitialCredentials("S1", "P1");
+    TimeSyncDisplayState state(&view, &controller);
+    DummySettingsState settings;
+    state.setManager(&manager);
+    state.setSettingsDisplayState(&settings);
+    manager.setState(&state);
+    controller.cancelCount = 0;
+    manager.handleButtonC();
+    TEST_ASSERT_EQUAL(1, controller.cancelCount);
+}
+
+void test_time_sync_button_c_transitions_to_settings_with_controller() {
+    StateManager manager;
+    MockTimeSyncView view;
+    MockTimeSyncController controller;
+    controller.setInitialCredentials("S1", "P1");
+    TimeSyncDisplayState state(&view, &controller);
+    DummySettingsState settings;
+    state.setManager(&manager);
+    state.setSettingsDisplayState(&settings);
+    manager.setState(&state);
+    manager.handleButtonC();
+    TEST_ASSERT_EQUAL((IState*)&settings, manager.getCurrentState());
+}
+
 int main() {
     UNITY_BEGIN();
     RUN_TEST(test_time_sync_title_join_ap);
@@ -73,6 +179,25 @@ int main() {
     RUN_TEST(test_time_sync_c_short_exit_to_settings);
     RUN_TEST(test_time_sync_on_draw_does_not_redraw_title);
     RUN_TEST(test_time_sync_on_draw_does_not_redraw_hints);
+    // New tests for Step1 behavior with controller
+    void test_time_sync_on_enter_calls_begin_once();
+    void test_time_sync_on_enter_shows_wifi_qr_called();
+    void test_time_sync_on_enter_shows_wifi_qr_payload_exact();
+    void test_time_sync_on_draw_calls_loop_tick_once();
+    void test_time_sync_on_draw_does_not_redraw_qr();
+    void test_time_sync_button_a_calls_reissue_once();
+    void test_time_sync_button_a_updates_qr_payload();
+    void test_time_sync_button_c_calls_cancel_once();
+    void test_time_sync_button_c_transitions_to_settings_with_controller();
+    RUN_TEST(test_time_sync_on_enter_calls_begin_once);
+    RUN_TEST(test_time_sync_on_enter_shows_wifi_qr_called);
+    RUN_TEST(test_time_sync_on_enter_shows_wifi_qr_payload_exact);
+    RUN_TEST(test_time_sync_on_draw_calls_loop_tick_once);
+    RUN_TEST(test_time_sync_on_draw_does_not_redraw_qr);
+    RUN_TEST(test_time_sync_button_a_calls_reissue_once);
+    RUN_TEST(test_time_sync_button_a_updates_qr_payload);
+    RUN_TEST(test_time_sync_button_c_calls_cancel_once);
+    RUN_TEST(test_time_sync_button_c_transitions_to_settings_with_controller);
     return UNITY_END();
 }
 


### PR DESCRIPTION
## 概要
AIM-48 Step1（MVP2）として SoftAP の起動/停止と Wi‑Fi 接続QR の表示を実装。UIは仕様書のタイトル/ヒント準拠、A=REISSUE, B=未使用, C=EXIT。URL QR 自動切替はスコープ外（後続）。

## 変更点
- lib: `TimeSyncCore` の追加（`buildWifiQrPayload()` 実装、エスケープ対応）
- lib: `ITimeSyncController` 追加
- lib: `TimeSyncDisplayState` を Controller連携対応（begin/loopTick/reissue/cancel）
- test: `test_time_sync_core_pure` 新設、`test_time_sync_display_pure` 追記（各1アサート方針）
- src: `SoftApTimeSyncController` 追加（Step1: SSID/PSK/token生成＋SoftAP起動/停止/再発行）
- src: `TimeSyncViewImpl::showWifiQr` 実装（QRCode+M5GFX、ECC LOW/quiet zone=2/上余白10px/黒地+アンバー）
- pio: `platformio.ini` に QRCode 依存を追加

## 動作/テスト
- native: pio test 全緑（247/247）
- coverage: quick 81.9%（閾値80%超）
- m5stack-fire: ビルド成功

## 受入観点（DoD）
- Step1画面表示とタイトル/ヒント（"TIME SYNC > JOIN AP", A=REISSUE/B空/C=EXIT）
- A短押しで資格情報再発行→QR更新
- C短押しで SoftAP 停止→`SETTINGS_MENU`
- テスト/カバレッジ 緑

## 参照
- #71 AIM-48
- `doc/spec/time_sync_ui_spec.md`
- `doc/design/softap_qr_time_sync_poc.md`
- `doc/design/ui_state_management.md`
