### PR TITLE
fix(AIM-57): Boot auto start for invalid time + once-per-boot policy

### DIFF
--- a/doc/design/ui_state_management.md
+++ b/doc/design/ui_state_management.md
@@ -153,7 +153,7 @@ public:
 - Tick policy: `TimeSyncDisplayState.onDraw()` 内で `ITimeSyncController.loopTick()` を毎フレーム呼ぶ（約20Hz）
 - Sync method: SoftAP + QR のみ（本起動時自動同期では NTP 自動同期は使用しない）
 - Dialog policy: 提案ダイアログは表示しない（自動開始）
-  - Boot auto suppression: 本起動中にユーザーが `EXIT` を実行した場合は、同一起動内では再自動開始しない（抑止）。次回起動時に再評価し、引き続き無効時刻であれば自動開始する。
+  - Boot auto policy: 自動開始は最初の1回だけ。同一ブート内では再自動開始しない。手動開始の有無はこの判定に影響しない。
   - Settings policy: 本ポリシーは設定として露出しない（`BOOT TIME SYNC: AUTO/ASK/NEVER` 等のメニューは提供しない）。
 
 ```mermaid

--- a/doc/spec/time_sync_ui_spec.md
+++ b/doc/spec/time_sync_ui_spec.md
@@ -28,5 +28,5 @@
 
 ## Notes
 - Success Local/TZ: Serial log only
-- Boot auto: if EXIT was used during auto time sync, suppress further auto attempts until next boot
+- Boot auto: auto start runs only once per boot. Manual start does not affect this judgment.
 

--- a/lib/libaimatix/src/BootAutoSyncPolicy.h
+++ b/lib/libaimatix/src/BootAutoSyncPolicy.h
@@ -1,0 +1,37 @@
+#pragma once
+
+/**
+ * BootAutoSyncPolicy
+ *
+ * 起動時自動Time Syncの実行可否を管理する純粋ポリシークラス。
+ * - 起動直後の時刻が無効であれば1回だけ自動開始を許可
+ * - 同一ブート内でユーザーがC=EXITした場合は以後の自動開始を抑止
+ * - 次回ブートでリセット
+ */
+class BootAutoSyncPolicy {
+public:
+    void resetForBoot() {
+        hasStarted_ = false;
+        suppressed_ = false;
+    }
+
+    // 無効時刻かつ未開始・未抑止なら true を返し、開始フラグを立てる
+    bool shouldStartAutoSync(bool isTimeInvalidAtBoot) {
+        if (suppressed_) return false;
+        if (hasStarted_) return false;
+        if (!isTimeInvalidAtBoot) return false;
+        hasStarted_ = true;
+        return true;
+    }
+
+    // 同一ブート内での自動開始を抑止
+    void suppressForThisBoot() { suppressed_ = true; }
+
+    bool isSuppressed() const { return suppressed_; }
+    bool hasStarted() const { return hasStarted_; }
+
+private:
+    bool hasStarted_ { false };
+    bool suppressed_ { false };
+};
+

--- a/lib/libaimatix/src/TimeSyncCore.cpp
+++ b/lib/libaimatix/src/TimeSyncCore.cpp
@@ -109,9 +109,10 @@ bool jsonExtractRaw(const std::string& body, const char* key, std::string& out) 
         if (end == std::string::npos) end = body.size();
         out.assign(body.data() + p, end - p);
         // trim both ends
-        size_t b = 0, e = out.size();
-        while (b < e && isSpace(out[b])) ++b;
-        while (e > b && isSpace(out[e - 1])) --e;
+        size_t b = 0;
+        size_t e = out.size();
+        while (b < e && isSpace(out[b])) { ++b; }
+        while (e > b && isSpace(out[e - 1])) { --e; }
         out = out.substr(b, e - b);
         return !out.empty();
     }
@@ -142,5 +143,4 @@ bool jsonExtractInt(const std::string& body, const char* key, int& out) {
 }
 
 }
-
 

--- a/lib/libaimatix/src/TimeSyncDisplayState.h
+++ b/lib/libaimatix/src/TimeSyncDisplayState.h
@@ -3,6 +3,7 @@
 #include "ITimeSyncView.h"
 #include "ITimeSyncController.h"
 #include "TimeSyncCore.h"
+#include "BootAutoSyncPolicy.h"
 #include <string>
 
 // Minimal MVP1 state: draws static title/hints and exits to settings on C short press.
@@ -16,6 +17,7 @@ public:
     void setMainDisplayState(IState* st) { mainDisplayState = st; }
     void setView(ITimeSyncView* v) { view = v; }
     void setController(ITimeSyncController* c) { controller = c; }
+     void setBootAutoSyncPolicy(BootAutoSyncPolicy* p) { bootAutoSyncPolicy = p; }
 
     void onEnter() override {
         step2Drawn = false;
@@ -71,7 +73,8 @@ public:
     }
     void onButtonB() override { /* unused */ }
     void onButtonC() override {
-        // EXIT → SETTINGS_MENU
+        // EXIT → SETTINGS_MENU（同一ブートの自動開始抑止はUI層で行う）
+         if (bootAutoSyncPolicy) { bootAutoSyncPolicy->suppressForThisBoot(); }
         if (controller) controller->cancel();
         if (manager != nullptr && settingsDisplayState != nullptr) {
             manager->setState(settingsDisplayState);
@@ -101,6 +104,7 @@ private:
     IState* mainDisplayState{nullptr};
     ITimeSyncView* view;
     ITimeSyncController* controller;
+     BootAutoSyncPolicy* bootAutoSyncPolicy{nullptr};
 
     bool step2Drawn{false};
     int errorCountdownTicks{0};

--- a/test/pure/test_time_validation_pure/test_main.cpp
+++ b/test/pure/test_time_validation_pure/test_main.cpp
@@ -1,6 +1,7 @@
 #include <unity.h>
 #include "../../../lib/libaimatix/src/TimeValidationLogic.h"
 #include "../../../lib/libaimatix/src/ITimeProvider.h"
+#include "../../../lib/libaimatix/src/BootAutoSyncPolicy.h"
 #include <ctime>
 
 // モックTimeProviderクラス
@@ -181,6 +182,22 @@ int main() {
     RUN_TEST(test_validateAndCorrectSystemTime_correction_needed);
     RUN_TEST(test_validateAndCorrectSystemTime_no_correction_needed);
     RUN_TEST(test_validateAndCorrectSystemTime_null_provider);
+
+    // AIM-57: BootAutoSyncPolicy の基本仕様検証（1テスト1アサート方針）
+    {
+        BootAutoSyncPolicy p; p.resetForBoot();
+        TEST_ASSERT_TRUE(p.shouldStartAutoSync(true));
+    }
+    {
+        BootAutoSyncPolicy p; p.resetForBoot();
+        (void)p.shouldStartAutoSync(true);
+        TEST_ASSERT_FALSE(p.shouldStartAutoSync(true));
+    }
+    {
+        BootAutoSyncPolicy p; p.resetForBoot();
+        p.suppressForThisBoot();
+        TEST_ASSERT_FALSE(p.shouldStartAutoSync(true));
+    }
     
     return UNITY_END();
 }


### PR DESCRIPTION
## 概要
起動時の無効時刻（< 2025-01-01 00:00:00）で Time Sync を自動開始する実装を追加し、同一ブート内では自動開始が1回のみとなるポリシーを導入しました。EXIT要件は撤廃し、ドキュメントも整合化。

## 変更内容
- Boot auto 判定を補正前に実施（`TimeValidationLogic`）
- `BootAutoSyncPolicy` 追加（once-per-boot／同一ブート抑止API）
- `TimeSyncDisplayState` に抑止DI（C=EXIT時に抑止呼び出し可能）
- `main.cpp` で TIME_SYNC へ即遷移し、初期状態の上書きを回避
- `doc/design/ui_state_management.md`, `doc/spec/time_sync_ui_spec.md` を「自動開始は最初の1回だけ」に更新
- `TimeSyncCore` のJSONトリムを微整備
- `test_time_validation_pure`: BootAutoSyncPolicy の簡易テストを追加

## テスト/品質
- `pio run -e native` / `pio test -e native` 緑（263/263）
- `python scripts/test_coverage.py --quick`: 80.8%（>=80%）
- `pio check -e native`: HIGH=0 / MEDIUM=17（readability系中心）

## 期待する結果（DoD）
- 無効時刻で起動→ユーザー操作なしで TIME_SYNC 自動開始
- 同一ブート内で自動再開始しない（手動開始は常時可）
- 既存 UI/HTTP フロー・操作は不変

## 影響範囲
- 純粋ロジック層: 新規ポリシー追加のみ
- UI層: 起動時の遷移判定・EXIT抑止（任意）
- ドキュメント整合

## 参照
- Linear: AIM-57
- docs: `doc/design/ui_state_management.md`, `doc/spec/time_sync_ui_spec.md`