### PR TITLE
feat(display): double-buffered fill for flash overlay via IDisplay::fillRectBuffered

### DIFF
--- a/lib/libaimatix/src/IDisplay.h
+++ b/lib/libaimatix/src/IDisplay.h
@@ -7,6 +7,10 @@ public:
     virtual void drawText(int x, int y, const char* text, int fontSize) = 0;
     virtual void setTextColor(uint16_t color, uint16_t bgColor) = 0;
     virtual void fillRect(int x, int y, int w, int h, uint16_t color) = 0;
+    // Double-buffered fill for flicker-free drawing. Default: fallback to fillRect.
+    virtual void fillRectBuffered(int x, int y, int w, int h, uint16_t color) {
+        fillRect(x, y, w, h, color);
+    }
     virtual void drawRect(int x, int y, int w, int h, uint16_t color) = 0;
     virtual void setTextDatum(uint8_t datum) = 0;
     virtual void setTextFont(int font) = 0;

--- a/src/AlarmActiveViewImpl.h
+++ b/src/AlarmActiveViewImpl.h
@@ -18,7 +18,7 @@ public:
         const int fillH = SCREEN_HEIGHT - HINT_HEIGHT - TITLE_HEIGHT;
         const uint16_t color = on ? AMBER_COLOR : TFT_BLACK;
         if (fillH > 0) {
-            disp_->fillRect(fillX, fillY, fillW, fillH, color);
+            disp_->fillRectBuffered(fillX, fillY, fillW, fillH, color);
         }
     }
 

--- a/src/DisplayAdapter.h
+++ b/src/DisplayAdapter.h
@@ -27,6 +27,14 @@ public:
         M5.Display.fillRect(x, y, w, h, color);
     }
 
+    void fillRectBuffered(int x, int y, int w, int h, uint16_t color) override {
+        M5Canvas canvas(&M5.Display);
+        canvas.createSprite(w, h);
+        canvas.fillSprite(color);
+        canvas.pushSprite(x, y);
+        canvas.deleteSprite();
+    }
+
     void drawRect(int x, int y, int w, int h, uint16_t color) override {
         M5.Display.drawRect(x, y, w, h, color);
     }


### PR DESCRIPTION
## 概要
中央領域の塗りつぶし描画でダブルバッファリング（スプライト）を使用し、フラッシュ時のちらつきを抑制します。

## 変更内容
- IDisplay: 後方互換な新API `fillRectBuffered(int x, int y, int w, int h, uint16_t color)` を追加
  - 既定実装は `fillRect(...)` を呼ぶため、未対応実装でも影響なし
- DisplayAdapter: `fillRectBuffered` を `M5Canvas` を用いたスプライト描画で実装
  - `createSprite` → `fillSprite` → `pushSprite` → `deleteSprite`
- AlarmActiveViewImpl: 中央領域の塗りつぶしを `fillRect` から `fillRectBuffered` に切替

## 動作確認
- ネイティブ環境
  - `pio run -e native`: 成功
  - `pio test -e native`: 285件すべて成功
- 実機（予定）
  - フラッシュ中の中央領域塗りつぶしでちらつきが抑制されること

## 影響範囲
- `IDisplay` インタフェースに新規メソッドを追加
  - 既定実装付きのため派生クラスのビルド破綻なし
  - 既存モック/他アダプタは未変更で動作継続
- `DisplayAdapter` のみM5依存の実体変更

## 品質
- コード規約: 抽象(`IDisplay`)を尊重しつつハード依存はアダプタに封じ込め
- テスト: 既存の純粋ロジックテストに影響なし（ネイティブで全件グリーン）
- 静的解析: CIのartifactsで最終確認予定

## 補足/今後の検討
- スプライトの毎回生成/破棄を採用（実装簡潔・安全）。必要に応じて中央領域固定サイズでのスプライトキャッシュ最適化を検討可能
- 一定以上の矩形塗りつぶしを常にダブルバッファに寄せる方針への拡張も可能