### PR TITLE
fix: アラーム繰り上がり直後に鳴動が解除される問題の修正

### DIFF
--- a/lib/libaimatix/src/AlarmActiveState.h
+++ b/lib/libaimatix/src/AlarmActiveState.h
@@ -13,6 +13,8 @@ public:
 
     void onEnter() override {
         elapsedMs_ = 0;
+        // 再入時に前回の開始時刻を引きずらないよう明示的にリセット
+        startedMs_ = 0;
         scheduler_.begin(0);
         // 次回onDrawで必ず一度だけ描画されるようエッジを強制
         lastOn_ = false;
@@ -22,6 +24,8 @@ public:
         // オーバーレイが残らないように必ずOFF描画
         if (view_) { view_->drawFlashOverlay(false); }
         baseDrawn_ = false;
+        // 念のため開始時刻もクリア
+        startedMs_ = 0;
     }
     void onDraw() override {
         // 経過時間を更新（単調msを使用）。フレームごとに差分加算にしても良いが、

--- a/test/pure/test_alarm_active_state_pure/test_main.cpp
+++ b/test/pure/test_alarm_active_state_pure/test_main.cpp
@@ -68,10 +68,47 @@ void test_on_exit_overlay_cleared(void) {
   TEST_ASSERT_FALSE(view.last);
 }
 
+void test_reenter_increases_draw_calls(void) {
+  StateManager mgr;
+  DummyState main;
+  MockView view;
+  MockTimeService ts;
+  AlarmActiveState s(&mgr, &view, &main, &ts);
+
+  ts.ms = 0;
+  s.onEnter();
+  ts.ms = 5000;     // 1回目は終了相当まで進める
+  s.onDraw();
+
+  int before = view.calls;
+  s.onEnter();      // 再入
+  s.onDraw();       // 初期ONエッジで描画が増えるはず
+  TEST_ASSERT_TRUE(view.calls > before);
+}
+
+void test_reenter_last_state_is_on(void) {
+  StateManager mgr;
+  DummyState main;
+  MockView view;
+  MockTimeService ts;
+  AlarmActiveState s(&mgr, &view, &main, &ts);
+
+  ts.ms = 0;
+  s.onEnter();
+  ts.ms = 5000;
+  s.onDraw();
+
+  s.onEnter();      // 再入
+  s.onDraw();
+  TEST_ASSERT_TRUE(view.last);
+}
+
 int main(int, char**) {
   UNITY_BEGIN();
   RUN_TEST(test_overlay_called_only_on_toggle_edges);
   RUN_TEST(test_on_exit_overlay_cleared);
+  RUN_TEST(test_reenter_increases_draw_calls);
+  RUN_TEST(test_reenter_last_state_is_on);
   return UNITY_END();
 }
 


### PR DESCRIPTION
## 概要
- alarmList の先頭が消化されて繰り上がる直後に、鳴動状態が即座に解除される不具合を修正

## 変更内容
- AlarmActiveState::onEnter() で `startedMs_` をリセット
- AlarmActiveState::onExit() でも安全のため `startedMs_` をリセット
- 再入時の初期ONエッジ描画を検証するテストを追加（1アサーション/テストの方針に準拠）

## テスト
- 環境: PlatformIO native
- 実行: `pio test -e native`
- 結果: 既存＋追加テストを含め全て成功

## 確認事項
- 鳴動開始→先頭アラーム消化→次アラーム繰り上がりの瞬間に鳴動が維持されること
- 既存の表示・進捗・アラーム管理画面の動作に回帰が無いこと

## 影響範囲
- `lib/libaimatix/src/AlarmActiveState.h`
- `test/pure/test_alarm_active_state_pure/test_main.cpp`

## 関連
- ラベル: `hw-ok`（作成後に付与）