### PR TITLE
Core2 lab: skip boot auto time sync (#116)

### DIFF
--- a/doc/operation/platformio_best_practices.md
+++ b/doc/operation/platformio_best_practices.md
@@ -111,6 +111,26 @@ build_unflags = -std=gnu++11
 ```
 
 - **build_src_filter**等は未使用。LDF（Library Dependency Finder）でlib/配下の自作ロジックを自動認識。
+
+## 3.1 実機テスト用ラボ環境（Core2）
+
+Core2 ラボ環境では、起動時の自動Time Sync開始を抑止するためのビルドフラグを用意しています。
+
+```ini
+[env:m5stack-core2-lab]
+extends = env:m5stack-core2
+build_flags =
+    ${env:m5stack-core2.build_flags}
+    -DSKIP_BOOT_AUTO_SYNC
+```
+
+- `SKIP_BOOT_AUTO_SYNC` が定義されている場合、`src/main.cpp` の起動時自動Time Sync処理（`resetForBoot()` 呼び出しから自動遷移の if ブロックまで）が無効化されます。
+- 使い方（例）:
+
+```bash
+platformio run -e m5stack-core2-lab
+```
+
 - **test/pure/**配下の各ディレクトリにtest_main.cppが1つずつ。
 - **mockのインクルード**は "mock/xxx.h" または "mock_button_manager.h" などで相対パス指定。
 

--- a/platformio.ini
+++ b/platformio.ini
@@ -58,6 +58,13 @@ build_flags =
 build_src_filter = +<*>
     -<native_main.cpp>
 
+; Core2 ラボ環境（自動Time Sync開始を抑止）
+[env:m5stack-core2-lab]
+extends = env:m5stack-core2
+build_flags =
+    ${env:m5stack-core2.build_flags}
+    -DSKIP_BOOT_AUTO_SYNC
+
 ; Native環境（純粋ロジックテスト用）
 [env:native]
 platform = native

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -150,6 +150,7 @@ void setup() {
     
     // Boot Auto: 無効時刻ならTime Sync自動開始（EXITで同一ブート抑止）
     // 注意: 自動開始の判定は「補正前の生時刻」で行う
+    #ifndef SKIP_BOOT_AUTO_SYNC
     g_boot_auto_policy.resetForBoot();
     const bool isInvalidAtBoot = TimeValidationLogic::isSystemTimeBeforeMinimum(g_time_service);
 
@@ -164,6 +165,7 @@ void setup() {
         time_sync_display_state.setBootAutoSyncPolicy(&g_boot_auto_policy);
         state_manager.setState(&time_sync_display_state);
     }
+    #endif
 
     // --- 状態遷移の依存注入（@/design/ui_state_management.md準拠） ---
     input_display_state.setManager(&state_manager);


### PR DESCRIPTION
## 概要
Core2 実機テスト向けに、起動時の Time Sync 自動開始を抑止するラボ環境 `env:m5stack-core2-lab` を追加しました。初期時刻の設定挙動は現状維持です。

## 変更点
- platformio.ini: `env:m5stack-core2-lab` を追加し `-DSKIP_BOOT_AUTO_SYNC` を付与
- src/main.cpp: `resetForBoot()` 呼び出しから自動遷移の if ブロック終端までを `#ifndef SKIP_BOOT_AUTO_SYNC ... #endif` でガード
- ドキュメント: `doc/operation/platformio_best_practices.md` にラボ環境の利用方法を追記

## 受け入れ基準
- `env:m5stack-core2-lab` で起動時に Time Sync UI へ遷移しない
- 通常環境（`env:m5stack-core2` / `env:m5stack-fire`）では現行動作を維持

## テスト
- `pio run -e native` 成功
- `pio run -e m5stack-core2` 成功
- `pio run -e m5stack-core2-lab` 成功（サイズ・依存ともに問題なし）
- `pio run -e m5stack-fire` 成功
- `python scripts/test_coverage.py --quick` 実行（81.1%）。Windows 端末の cp932 環境で絵文字出力に起因する警告表示がありますが、測定自体は完了

## 使い方
```bash
platformio run -e m5stack-core2-lab
```

## 影響範囲
- 追加環境のみ挙動変更。既存環境（`m5stack-core2` / `m5stack-fire`）は非影響

## 関連
Closes #116