### PR TITLE
Core2: ABC press/longPressで100ms/100%バイブ再生（#128基盤活用）

### DIFF
--- a/lib/libaimatix/src/ButtonManager.cpp
+++ b/lib/libaimatix/src/ButtonManager.cpp
@@ -18,6 +18,7 @@ void ButtonManager::update(ButtonType btn, bool pressed, uint32_t now_ms) {
         if (pressed) {
             // 押下開始
             btn_state.pressStart = now_ms;
+            btn_state.pressDownEdge = true; // 立ち上がりエッジ
             btn_state.shortFired = false;
             btn_state.longFired = false;
             btn_state.fired = false;
@@ -36,6 +37,16 @@ void ButtonManager::update(ButtonType btn, bool pressed, uint32_t now_ms) {
         btn_state.longFired = true;
         btn_state.fired = true;
     }
+}
+
+auto ButtonManager::isPressDown(ButtonType btn) const -> bool {
+    auto btn_index = static_cast<size_t>(btn);
+    if (btn < 0 || btn_index >= sizeof(btnStates)/sizeof(btnStates[0])) {
+        return false; // 無効なボタンタイプ
+    }
+    const bool ret = btnStates[btn_index].pressDownEdge;
+    const_cast<BtnState&>(btnStates[btn_index]).pressDownEdge = false;
+    return ret;
 }
 
 auto ButtonManager::isShortPress(ButtonType btn) const -> bool {
@@ -64,4 +75,4 @@ void ButtonManager::reset(ButtonType btn) {
         return; // 無効なボタンタイプ
     }
     btnStates[btn_index] = BtnState();
-} 
+}

--- a/lib/libaimatix/src/ButtonManager.h
+++ b/lib/libaimatix/src/ButtonManager.h
@@ -8,6 +8,8 @@ public:
 
     // ボタン状態を更新（押下/離上/時刻）
     void update(ButtonType btn, bool pressed, uint32_t now_ms);
+    // 立ち上がりエッジ（press瞬間）検出
+    bool isPressDown(ButtonType btn) const;
     // 短押し判定
     bool isShortPress(ButtonType btn) const;
     // 長押し判定
@@ -19,10 +21,11 @@ private:
         bool pressed = false;
         uint32_t pressStart = 0;
         uint32_t lastChange = 0;
+        bool pressDownEdge = false;
         bool shortFired = false;
         bool longFired = false;
         bool fired = false;
     } btnStates[3];
     static constexpr uint32_t BM_LONG_PRESS_MS = 500;
     static constexpr uint32_t BM_DEBOUNCE_MS = 50;
-}; 
+};

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -153,8 +153,7 @@ void setup() {
     Serial.begin(cfg.serial_baudrate);
     Serial.println("[BOOT] M5.begin done");
     M5.Display.setTextColor(AMBER_COLOR, TFT_BLACK);
-    // --- Core2: バイブレーションパターンを設定し開始する（例: 100ms ON→100ms OFF→100ms ON→...） ---
-#ifdef M5STACK_CORE2
+#if defined(M5STACK_CORE2) && defined(ENABLE_CORE2_BOOT_VIBE_DEMO)
     g_vibe_seq.loadPattern({
         {100, 100},   // 100ms ON（100%）
         {100, 0},     // 100ms OFF
@@ -237,8 +236,23 @@ void loop() {
         current->onDraw();
     }
 
-    // --- Core2: Vibration update ---
+    // --- Core2: Haptics feedback on press/longPress ---
 #ifdef M5STACK_CORE2
+    // 設定: press/longPressで個別のパターン（初期: 100ms/100%）
+    static const std::vector<VibrationSequencer::Segment> kPressDownPattern = { {100, 100} };
+    static const std::vector<VibrationSequencer::Segment> kLongPressPattern = { {100, 100} };
+    if (button_manager.isPressDown(ButtonManager::BtnA) ||
+        button_manager.isPressDown(ButtonManager::BtnB) ||
+        button_manager.isPressDown(ButtonManager::BtnC)) {
+        g_vibe_seq.loadPattern(kPressDownPattern, false);
+        g_vibe_seq.start(millis());
+    }
+    if (button_manager.isLongPress(ButtonManager::BtnA) ||
+        button_manager.isLongPress(ButtonManager::BtnB) ||
+        button_manager.isLongPress(ButtonManager::BtnC)) {
+        g_vibe_seq.loadPattern(kLongPressPattern, false);
+        g_vibe_seq.start(millis());
+    }
     g_vibe_seq.update(millis(), &g_vibe_out);
 #endif
     delay(LOOP_DELAY_MS);

--- a/test/pure/test_button_manager_pure/test_main.cpp
+++ b/test/pure/test_button_manager_pure/test_main.cpp
@@ -59,6 +59,23 @@ void test_debounce_edge_and_reset() {
     TEST_ASSERT_FALSE(bm2.isLongPress(ButtonManager::BtnC));
 }
 
+void test_press_down_edge_single_shot_and_debounce() {
+    ButtonManager bm;
+    uint32_t t = 5000;
+    // 立ち上がりで1回だけtrue、その後押しっぱなしではfalse
+    bm.update(ButtonManager::BtnA, true, t);      // 押下（エッジ）
+    TEST_ASSERT_TRUE(bm.isPressDown(ButtonManager::BtnA));
+    TEST_ASSERT_FALSE(bm.isPressDown(ButtonManager::BtnA));
+    // デバウンス未満の反転は無視
+    bm.update(ButtonManager::BtnA, false, t+10);  // 10msで離す（無視）
+    bm.update(ButtonManager::BtnA, true, t+15);   // さらに押下（無視）
+    TEST_ASSERT_FALSE(bm.isPressDown(ButtonManager::BtnA));
+    // デバウンスを超えた後の再押下で再度true
+    bm.update(ButtonManager::BtnA, false, t+200); // 安定した離し
+    bm.update(ButtonManager::BtnA, true, t+260);  // 再押下（エッジ）
+    TEST_ASSERT_TRUE(bm.isPressDown(ButtonManager::BtnA));
+}
+
 void setUp(void) {}
 void tearDown(void) {}
 
@@ -68,6 +85,7 @@ int main(int argc, char **argv) {
     RUN_TEST(test_long_press);
     RUN_TEST(test_debounce);
     RUN_TEST(test_debounce_edge_and_reset);
+    RUN_TEST(test_press_down_edge_single_shot_and_debounce);
     UNITY_END();
     return 0;
-} 
+}


### PR DESCRIPTION
## 概要
- Issue: #129
- Core2 で A/B/C の press 立ち上がりと長押し認定時に、100ms・100% duty のバイブレーションをワンショット再生します。
- 再生中でも上書き開始（アラーム時の停止仕様と整合）。
- Fire には影響なし。

## 変更点
- ButtonManager に `isPressDown(ButtonType)` を追加（デバウンス後の立ち上がりエッジを1回だけ返す）。
- `src/main.cpp`
  - Core2 起動デモ振動を `ENABLE_CORE2_BOOT_VIBE_DEMO` で封止（デフォルト無効）。
  - Core2 限定で press/longPress フックを追加し、`VibrationSequencer` にパターン `{ {100, 100} }` を `loadPattern(...); start(...)` で上書き開始。
  - press/longPress それぞれ別パターン変数を用意（将来の調整に対応）。
- テスト: `test/pure/test_button_manager_pure`
  - 立ち上がりエッジの1回性、デバウンス、連打での再発火を検証するテストを追加。

## ビルド/テスト
- native: pio run/pio test → 全テスト成功
- core2/fire: pio run → 成功
- クイックカバレッジ: 81.0%（ゲート>=80% クリア）

## 受け入れ基準との対応
- Core2 実機で press/longPress 双方で 100ms/100% が1回ずつ鳴動する実装（上書き開始）。
- Fire ビルド/挙動に変化なし。
- 既存テストとクイックカバレッジに退行なし。

## 今後の調整ポイント（実機触感）
- `kPressDownPattern` / `kLongPressPattern` は個別に調整可能。現状どちらも `{ {100, 100} }`。

## 参考
- [PR #128](https://github.com/ycums/Aimatix/pull/128) の `IVibration`/`VibrationSequencer`/`Core2VibrationAdapter` を活用